### PR TITLE
Remove placeholder newsletter form on insights page

### DIFF
--- a/insights.html
+++ b/insights.html
@@ -84,10 +84,9 @@
       <div class="container contact-container">
         <h2 id="cta-title" class="section-title">Have an Idea or Topic in Mind?</h2>
         <p>We welcome collaboration and guest contributions on topics around urban planning, sustainability, and engineering innovation.</p>
-        <form action="YOUR_NEWSLETTER_FORM_ACTION" method="post" class="signup-inline" style="display:flex;gap:.5rem;flex-wrap:wrap;">
-          <input type="email" name="email" placeholder="you@example.com" required aria-label="Email address">
-          <button type="submit" class="btn-primary">Subscribe</button>
-        </form>
+        <p style="max-width: 480px; margin: 0 auto 1.25rem;">
+          Subscribe to our newsletter to stay informed on the latest insights. Sign-up options are coming soon.
+        </p>
         <a href="../contact.html" class="btn-primary">Contact Us</a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove the placeholder newsletter signup form from the Insights page
- add placeholder copy letting visitors know that subscription options are coming soon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad675e06c8324818cfd6c880f14fe