### PR TITLE
Fix Nigeria story map markup and script loading

### DIFF
--- a/staygis-blog/index.qmd
+++ b/staygis-blog/index.qmd
@@ -22,7 +22,20 @@ If **Map B** fails, weâ€™ll know itâ€™s the storymap plugin or data pa
 <div id="mapA" style="width:100%;height:420px;border-radius:10px;overflow:hidden"></div>
 
 ## Map B â€” StoryMap (slides + points)
-<div id="mapB" style="width:100%;height:620px;border-radius:10px;overflow:hidden"></div>
+<div id="story" role="region" aria-labelledby="slides-title" style="display:grid;grid-template-columns:1fr;gap:14px;margin-top:16px">
+  <div id="mapB" style="width:100%;height:620px;border-radius:10px;overflow:hidden" aria-label="Nigeria flythrough map"></div>
+  <div>
+    <h3 id="slides-title" style="margin:.2rem 0 .6rem">Four moments to fly through</h3>
+    <div id="slides" style="background:#fff;border:1px solid #e6e6e6;border-radius:10px;padding:16px"></div>
+    <div style="display:flex;gap:.5rem;margin-top:.6rem;flex-wrap:wrap">
+      <button id="prev" type="button" aria-label="Previous slide" style="padding:.55rem .8rem;border-radius:.6rem;border:1px solid #e6e6e6;background:#fff">◀ Prev</button>
+      <button id="next" type="button" aria-label="Next slide" style="padding:.55rem .8rem;border-radius:.6rem;border:1px solid #e6e6e6;background:#fff">Next ▶</button>
+      <a id="share-x" href="#" rel="noopener" aria-label="Share on X" style="padding:.55rem .8rem;border-radius:.6rem;border:1px solid #e6e6e6;background:#fff;text-decoration:none">Share on X</a>
+      <a id="share-li" href="#" rel="noopener" aria-label="Share on LinkedIn" style="padding:.55rem .8rem;border-radius:.6rem;border:1px solid #e6e6e6;background:#fff;text-decoration:none">Share on LinkedIn</a>
+      <button id="copy-link" type="button" aria-label="Copy link" style="padding:.55rem .8rem;border-radius:.6rem;border:1px solid #e6e6e6;background:#fff">Copy link</button>
+    </div>
+  </div>
+</div>
 
 ```{=html}
 <!-- Leaflet core -->
@@ -34,3 +47,6 @@ If **Map B** fails, weâ€™ll know itâ€™s the storymap plugin or data pa
 <script src="https://unpkg.com/leaflet-storymap@1.0.0/dist/leaflet.storymap.min.js"></script>
 
 <!-- Our scripts (must come after Leaflet) -->
+<script defer src="posts/2025-10-01-nigeria-65/nigeria-post.js"></script>
+```
+

--- a/staygis-blog/posts/2025-10-01-nigeria-65/index.qmd
+++ b/staygis-blog/posts/2025-10-01-nigeria-65/index.qmd
@@ -100,3 +100,5 @@ resources:
 
 <!-- Our app code (loads points + slides JSON) -->
 <script defer src="nigeria-post.js"></script>
+```
+


### PR DESCRIPTION
## Summary
- add the homepage story-map slider markup and load the Nigeria post script so Map B can initialize
- close the raw HTML fence in the Nigeria @ 65 post to keep the slider controls rendering as markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db18c60c988324a1291cdb7a41fdcf